### PR TITLE
暗号用語の統一と教育的改善

### DIFF
--- a/src/pages/PublicKey.tsx
+++ b/src/pages/PublicKey.tsx
@@ -10,11 +10,11 @@ const description = {
   summary:
     '楕円曲線 Diffie-Hellman (ECDH) で共有秘密を作り、HKDF で AES-GCM 用の対称キーへ導き、短文を暗号化するデモです。',
   details:
-    'P-256 曲線で Alice/Bob の鍵ペアを生成し、互いの公開鍵から同じ共有秘密 Z を求めます。その Z と塩・info を HKDF に通すことで 256bit キーを得ます。これを使って AES-GCM でメッセージを暗号化します。秘密一致フラグや Base64 表示で状態が確認できます。',
+    'P-256 曲線で Alice/Bob の鍵ペアを生成し、互いの公開鍵から同じ共有秘密 Z を求めます。その Z とソルト・info を HKDF に通すことで 256bit キーを得ます。これを使って AES-GCM でメッセージを暗号化します。秘密一致フラグや Base64 表示で状態が確認できます。',
   points: [
-    '塩 (salt) は共有秘密から独立したランダム値。毎回変えるのが理想。',
+    'ソルト (salt) は共有秘密から独立したランダム値。毎回変えるのが理想。',
     'info は用途ラベル。文字列を自由に設定可能。',
-    'HKDF で得たキーが揃えば、どちらの側でも同じ AES-GCM 結果が得られる。',
+    'HKDF で鍵導出すれば、どちらの側でも同じ AES-GCM 結果が得られる。',
   ],
 }
 
@@ -92,7 +92,7 @@ export default function PublicKeyPage() {
       setSharedB(bytesToBase64(zb))
       setDerivedKey(derived)
       setDecryptedText('')
-      setStatus('鍵共有に成功。Derived Key を使って暗号化できます。')
+      setStatus('鍵共有に成功。導出された鍵を使って暗号化できます。')
     } catch (error) {
       setStatus(error instanceof Error ? error.message : '鍵共有に失敗しました。', 'error')
       setSharedMatch('unknown')
@@ -155,11 +155,11 @@ export default function PublicKeyPage() {
 
       <section className="card">
         <div className="card-header">
-          <h2>共通キーの生成</h2>
-          <p>塩 (salt) と info を決め、EC 鍵共有→HKDF を実行します。</p>
+          <h2>共有鍵の生成</h2>
+          <p>ソルト (salt) と info を決め、EC 鍵共有→HKDF で鍵導出を実行します。</p>
         </div>
 
-        <label htmlFor="salt">塩 (Base64)</label>
+        <label htmlFor="salt">ソルト (Base64)</label>
         <div className="row-with-button">
           <input
             id="salt"
@@ -174,7 +174,7 @@ export default function PublicKeyPage() {
             onClick={() => setSaltBase64(randomSalt())}
             disabled={isProcessing}
           >
-            塩を再生成
+            ソルトを再生成
           </button>
         </div>
 
@@ -278,7 +278,7 @@ export default function PublicKeyPage() {
       <section className="card caution">
         <h2>注意</h2>
         <ul>
-          <li>ECDH から得た共有秘密は必ず HKDF などでキー化し、直接 AES に使わないのが原則です。</li>
+          <li>ECDH から得た共有秘密は必ず HKDF などで鍵導出し、直接 AES に使わないのが原則です。</li>
           <li>公開鍵は証明書や署名で真正性を確認する必要があります。本デモでは省略しています。</li>
           <li>ここでの暗号化は短文向け。大きなファイルやストリームを扱う場合は追加の鍵管理やチャンク処理が必要です。</li>
         </ul>

--- a/src/pages/Symmetric.tsx
+++ b/src/pages/Symmetric.tsx
@@ -114,7 +114,7 @@ export default function SymmetricPage() {
           value={passphrase}
           onChange={(event) => setPassphrase(event.target.value)}
         />
-        <p className="hint">※ デモのため SHA-256 でそのままキー化しています。</p>
+        <p className="hint">※ デモのため SHA-256 でそのまま鍵導出しています。</p>
 
         <label htmlFor="plaintext">平文テキスト</label>
         <textarea


### PR DESCRIPTION
## 概要
暗号学の専門用語を統一し、教育コンテンツとしての質を向上させました。

## 変更内容

### 用語統一
- ✅ **「塩」→「ソルト」に全面統一**
  - 暗号学の専門用語として「ソルト」が一般的
  - プロジェクト全体で一貫性を確保
  
- ✅ **「キー化」→「鍵導出」に統一**
  - KDF (Key Derivation Function) の正式な訳語
  - より専門的で正確な表現

- ✅ **「共通キー」→「共有鍵」に修正（ECDH文脈）**
  - ECDHで生成される鍵は「共有鍵」が適切
  - 「共通鍵暗号」とは別の概念として明確化

### 修正ファイル

#### `src/pages/PublicKey.tsx`
- すべての「塩」表記を「ソルト」に変更（5箇所）
- 「共通キーの生成」→「共有鍵の生成」
- 「HKDF でキー化」→「HKDF で鍵導出」
- 「Derived Key」→「導出された鍵」（日本語として自然に）

#### `src/pages/Symmetric.tsx`
- 「SHA-256 でそのままキー化」→「SHA-256 でそのまま鍵導出」

## 検証
- [x] プロジェクト全体で「塩」が残っていないことを確認
- [x] 用語の一貫性をチェック
- [x] 既存の機能に影響がないことを確認

## スクリーンショット
変更は主に用語の統一であり、UIの表示が若干変わります：
- ラベル: "塩 (Base64)" → "ソルト (Base64)"
- ボタン: "塩を再生成" → "ソルトを再生成"
- セクション: "共通キーの生成" → "共有鍵の生成"

## 影響範囲
- 表示テキストのみの変更
- ロジックには影響なし
- 互換性の問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)