### PR TITLE
量子リポジトリへのリンクを削除

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,9 +11,6 @@ export default function Footer() {
           <a href="https://www.nist.gov/news-events/news/2022/07/nist-announces-first-four-quantum-resistant-cryptographic-algorithms" target="_blank" rel="noreferrer">
             NIST PQC 参考
           </a>
-          <a href="https://github.com/kaminuma/quantum-rsa-lab" target="_blank" rel="noreferrer">
-            Quantum RSA Lab
-          </a>
         </div>
       </div>
     </footer>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -72,17 +72,6 @@ export default function NavBar() {
               ))}
             </div>
           </div>
-
-          <a
-            className="nav-link"
-            href="https://github.com/kaminuma/quantum-rsa-lab"
-            target="_blank"
-            rel="noreferrer"
-            onClick={closeMenu}
-            style={{ border: '1px solid var(--color-border)', borderRadius: '999px' }}
-          >
-            Quantum RSA Lab ↗
-          </a>
         </nav>
       </div>
     </header>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -67,8 +67,7 @@ export default function Home() {
           ))}
         </ol>
         <p className="hint">
-          量子アルゴリズム実験は <a href="https://github.com/kaminuma/quantum-rsa-lab" target="_blank" rel="noreferrer">Quantum RSA Lab</a>{' '}
-          を参照してください。
+          量子アルゴリズム実験機能は現在開発中です。
         </p>
       </section>
     </div>


### PR DESCRIPTION
## 概要
開発段階のため、量子アルゴリズム実験リポジトリ (quantum-rsa-lab) への外部リンクを削除しました。

## 変更内容

### 削除したリンク
1. **NavBar.tsx**: ナビゲーションバーの "Quantum RSA Lab ↗" ボタンを削除
2. **Footer.tsx**: フッターの "Quantum RSA Lab" リンクを削除
3. **Home.tsx**: リンク付きテキストを「量子アルゴリズム実験機能は現在開発中です。」に変更

### 理由
- 量子リポジトリは現在開発段階
- 外部リンクを掲載するのは時期尚早
- ユーザーに混乱を与える可能性があるため

## テスト方法
1. ナビゲーションバーに "Quantum RSA Lab" ボタンが表示されないことを確認
2. フッターに "Quantum RSA Lab" リンクが表示されないことを確認
3. Homeページで「量子アルゴリズム実験機能は現在開発中です。」のテキストが表示されることを確認
4. すべてのページで正常にナビゲーションできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)