### PR TITLE
Enigma PC表示で横幅が広がりすぎる問題を修正

### DIFF
--- a/src/enigma/ui/enigma.css
+++ b/src/enigma/ui/enigma.css
@@ -14,7 +14,6 @@
 }
 
 .enigma-container {
-    background-color: var(--enigma-bg);
     color: var(--enigma-text);
     font-family: 'Courier New', Courier, monospace;
     /* Typewriter feel */
@@ -23,7 +22,8 @@
     display: flex;
     flex-direction: column;
     gap: 2rem;
-    background-image: radial-gradient(circle at 50% 50%, #2a2a2a 0%, #1a1a1a 100%);
+    max-width: 1200px;
+    margin: 0 auto;
 }
 
 .enigma-panel {
@@ -766,6 +766,8 @@
 .enigma-page {
     position: relative;
     min-height: 100vh;
+    background-color: var(--enigma-bg);
+    background-image: radial-gradient(circle at 50% 50%, #2a2a2a 0%, #1a1a1a 100%);
 }
 
 .enigma-back-btn {


### PR DESCRIPTION
## Summary
- `enigma-container` に `max-width: 1200px` を設定してPC表示時の横幅を制限
- 背景を `enigma-page` に移動し、コンテナ幅制限でも背景が画面全体に表示されるように

## Test plan
- [ ] PC表示でEnigmaページが適切な幅で表示されることを確認
- [ ] モバイル表示に影響がないことを確認
- [ ] 背景が画面全体に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)