### PR TITLE
PC表示を元に戻し、モバイル専用スタイルを追加

### DIFF
--- a/src/enigma/ui/enigma.css
+++ b/src/enigma/ui/enigma.css
@@ -14,6 +14,7 @@
 }
 
 .enigma-container {
+    background-color: var(--enigma-bg);
     color: var(--enigma-text);
     font-family: 'Courier New', Courier, monospace;
     /* Typewriter feel */
@@ -22,8 +23,7 @@
     display: flex;
     flex-direction: column;
     gap: 2rem;
-    max-width: 1200px;
-    margin: 0 auto;
+    background-image: radial-gradient(circle at 50% 50%, #2a2a2a 0%, #1a1a1a 100%);
 }
 
 .enigma-panel {
@@ -372,54 +372,14 @@
 }
 
 /* =========================================
-   ENIGMA MOBILE RESPONSIVE STYLES
+   MOBILE ONLY STYLES
+   PC layout is NOT affected (min-width: 769px)
    ========================================= */
 
-/* Grid Layout for Enigma - Default 3 columns */
-.grid {
-    display: grid;
-}
-
-.grid-cols-1 {
-    grid-template-columns: repeat(1, minmax(0, 1fr));
-}
-
-.lg\:grid-cols-3 {
-    grid-template-columns: repeat(1, minmax(0, 1fr));
-}
-
-@media (min-width: 1024px) {
-    .lg\:grid-cols-3 {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-    }
-}
-
-.gap-8 {
-    gap: 2rem;
-}
-
-.gap-4 {
-    gap: 1rem;
-}
-
-.max-w-7xl {
-    max-width: 80rem;
-}
-
-.mx-auto {
-    margin-left: auto;
-    margin-right: auto;
-}
-
-/* Mobile Enigma Container */
 @media (max-width: 768px) {
     .enigma-container {
         padding: 1rem;
         gap: 1rem;
-    }
-
-    .enigma-container h1 {
-        font-size: 1.5rem !important;
     }
 
     .enigma-panel {
@@ -428,13 +388,7 @@
 
     .enigma-title {
         font-size: 1.1rem;
-    }
-}
-
-/* Keyboard and Lamp Mobile */
-@media (max-width: 600px) {
-    .keyboard-row {
-        gap: 0.25rem;
+        letter-spacing: 1px;
     }
 
     .lamp {
@@ -447,16 +401,23 @@
         width: 30px;
         height: 30px;
         font-size: 0.75rem;
+        box-shadow: 0 2px 0 #333;
+    }
+
+    .key:active,
+    .key.pressed {
+        transform: translateY(2px);
     }
 
     .rotor-window {
-        font-size: 1.25rem;
+        font-size: 1.5rem;
         padding: 0.25rem 0.5rem;
-        min-width: 2rem;
+        min-width: 2.5rem;
     }
 
     .rotor-unit {
         padding: 0.5rem;
+        gap: 0.25rem;
     }
 
     .plugboard-grid {
@@ -465,23 +426,33 @@
     }
 
     .plug-socket {
-        width: 30px;
-        height: 30px;
-        font-size: 0.7rem;
+        width: 32px;
+        height: 32px;
+        font-size: 0.75rem;
+    }
+
+    .io-area {
+        font-size: 1rem;
+        min-height: 80px;
+        padding: 0.75rem;
     }
 }
 
 @media (max-width: 480px) {
     .lamp {
-        width: 28px;
-        height: 28px;
-        font-size: 0.7rem;
-    }
-
-    .key {
         width: 26px;
         height: 26px;
         font-size: 0.65rem;
+    }
+
+    .key {
+        width: 24px;
+        height: 24px;
+        font-size: 0.6rem;
+    }
+
+    .keyboard-row {
+        gap: 0.25rem;
     }
 
     .plugboard-grid {
@@ -491,301 +462,6 @@
     .plug-socket {
         width: 28px;
         height: 28px;
-    }
-}
-
-/* IO Area Mobile */
-@media (max-width: 768px) {
-    .io-area {
-        font-size: 1rem;
-        min-height: 80px;
-    }
-}
-
-/* Enigma Specs Button Mobile */
-@media (max-width: 600px) {
-    .enigma-container .absolute {
-        position: static !important;
-        transform: none !important;
-        margin-top: 0.5rem;
-    }
-
-    .enigma-container .text-center.relative {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 0.5rem;
-    }
-}
-
-/* Input/Output side by side to stacked on mobile */
-@media (max-width: 768px) {
-    .flex.gap-4 {
-        flex-direction: column;
-    }
-}
-
-/* Rotor group mobile */
-@media (max-width: 600px) {
-    .rotor-group {
-        gap: 0.5rem;
-    }
-}
-
-/* Text center */
-.text-center {
-    text-align: center;
-}
-
-/* Relative positioning */
-.relative {
-    position: relative;
-}
-
-/* Absolute positioning */
-.absolute {
-    position: absolute;
-}
-
-/* Transform utilities */
-.transform {
-    transform: translateX(var(--tw-translate-x, 0)) translateY(var(--tw-translate-y, 0));
-}
-
-.-translate-y-1\/2 {
-    --tw-translate-y: -50%;
-}
-
-/* Right positioning */
-.right-4 {
-    right: 1rem;
-}
-
-.top-1\/2 {
-    top: 50%;
-}
-
-/* Tracking */
-.tracking-widest {
-    letter-spacing: 0.2em;
-}
-
-.tracking-\[0\.5em\] {
-    letter-spacing: 0.5em;
-}
-
-/* Font utilities */
-.font-bold {
-    font-weight: 700;
-}
-
-.text-4xl {
-    font-size: 2.25rem;
-    line-height: 2.5rem;
-}
-
-@media (max-width: 600px) {
-    .text-4xl {
-        font-size: 1.5rem;
-        line-height: 2rem;
-    }
-}
-
-/* =========================================
-   NEW ENIGMA LAYOUT STYLES
-   ========================================= */
-
-/* Header */
-.enigma-header {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    position: relative;
-    padding: 0 1rem;
-}
-
-.enigma-header-content {
-    text-align: center;
-}
-
-.enigma-main-title {
-    font-size: 2.25rem;
-    font-weight: bold;
-    margin-bottom: 0.5rem;
-    letter-spacing: 0.2em;
-    color: #ffffff;
-    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.8);
-}
-
-.enigma-subtitle {
-    font-size: 0.75rem;
-    letter-spacing: 0.5em;
-    color: #b0b0b0;
-    text-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
-}
-
-.enigma-specs-btn {
-    position: absolute;
-    right: 1rem;
-    top: 50%;
-    transform: translateY(-50%);
-    font-size: 0.75rem;
-    padding: 0.5rem 1rem;
-}
-
-@media (max-width: 600px) {
-    .enigma-header {
-        flex-direction: column;
-        gap: 1rem;
-    }
-
-    .enigma-main-title {
-        font-size: 1.5rem;
-    }
-
-    .enigma-subtitle {
-        letter-spacing: 0.3em;
-        font-size: 0.65rem;
-    }
-
-    .enigma-specs-btn {
-        position: static;
-        transform: none;
-    }
-}
-
-/* Main Grid Layout */
-.enigma-main-grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
-    max-width: 80rem;
-    margin: 0 auto;
-    width: 100%;
-}
-
-@media (min-width: 1024px) {
-    .enigma-main-grid {
-        grid-template-columns: 1fr 1fr 1fr;
-        gap: 2rem;
-    }
-}
-
-/* Column styles */
-.enigma-settings-col,
-.enigma-keyboard-col,
-.enigma-io-col {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-/* Mode description */
-.enigma-mode-desc {
-    padding: 1rem;
-}
-
-.enigma-mode-text {
-    font-size: 0.75rem;
-    line-height: 1.6;
-    color: #e5e7eb;
-}
-
-.enigma-mode-text p {
-    margin: 0;
-}
-
-.enigma-mode-label {
-    font-weight: bold;
-}
-
-.enigma-mode-label.realism {
-    color: #818cf8;
-}
-
-.enigma-mode-label.batch {
-    color: var(--enigma-accent);
-}
-
-/* IO Wrapper */
-.enigma-io-wrapper {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-/* IO Side by Side (batch mode) */
-.enigma-io-side-by-side {
-    display: flex;
-    gap: 1rem;
-}
-
-@media (max-width: 768px) {
-    .enigma-io-side-by-side {
-        flex-direction: column;
-    }
-}
-
-/* IO Stack (realism mode) */
-.enigma-io-stack {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    width: 100%;
-}
-
-/* Log Area */
-.enigma-log-area {
-    background: #111827;
-    padding: 1rem;
-    border-radius: 8px;
-    border: 1px solid #374151;
-    min-height: 8rem;
-    overflow-y: auto;
-    font-family: 'Courier New', Courier, monospace;
-    font-size: 0.875rem;
-    color: #d1d5db;
-}
-
-.enigma-log-label {
-    font-size: 0.75rem;
-    color: #6b7280;
-    margin-bottom: 0.25rem;
-}
-
-.enigma-log-content {
-    word-break: break-all;
-}
-
-.enigma-log-placeholder {
-    color: #4b5563;
-    font-style: italic;
-}
-
-/* Enigma Page Back Button */
-.enigma-page {
-    position: relative;
-    min-height: 100vh;
-    background-color: var(--enigma-bg);
-    background-image: radial-gradient(circle at 50% 50%, #2a2a2a 0%, #1a1a1a 100%);
-}
-
-.enigma-back-btn {
-    position: absolute;
-    top: 20px;
-    left: 20px;
-    z-index: 100;
-    padding: 8px 16px;
-}
-
-@media (max-width: 600px) {
-    .enigma-back-btn {
-        position: static;
-        margin-bottom: 1rem;
-        display: inline-block;
-    }
-
-    .enigma-page {
-        padding-top: 0;
+        font-size: 0.6rem;
     }
 }


### PR DESCRIPTION
- PC表示: モバイルフレンドリー対応前の状態に復元
- モバイル (768px以下): キー、ランプ、プラグボードを縮小
- 小型スマホ (480px以下): さらにコンパクトに調整