### PR TITLE
モバイルNavBarをデフォルトで閉じた状態に修正

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -204,11 +204,18 @@ a:hover {
   padding: var(--spacing-xs);
 }
 
+/* Navigation Links Container */
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
 @media (max-width: 768px) {
   .menu-toggle {
     display: block;
   }
-  
+
   .nav-links {
     display: none;
     flex-direction: column;
@@ -221,17 +228,10 @@ a:hover {
     border-bottom: 1px solid var(--color-border);
     z-index: 100;
   }
-  
+
   .nav-links.open {
     display: flex;
   }
-}
-
-/* Navigation Links Container */
-.nav-links {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
 }
 
 /* Navigation Links */


### PR DESCRIPTION
## Summary
- CSSの順序問題を修正
- メディアクエリを後に配置し、モバイルで`display:none`が正しく適用されるように
- スマホでNavBarがデフォルトで開いたままになる問題を解決

## Test plan
- [ ] モバイル表示でNavBarが初期状態で閉じていることを確認
- [ ] ハンバーガーメニュークリックで開閉することを確認
- [ ] PC表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)