### PR TITLE
鍵導出関数(PBKDF2)とDH鍵交換デモを既存ページに追加

### DIFF
--- a/src/pages/Hash.tsx
+++ b/src/pages/Hash.tsx
@@ -668,6 +668,238 @@ function RealWorldUses() {
 }
 
 /* =========================================
+   Step 11: 鍵導出関数 — パスワードから鍵を作る
+   ========================================= */
+function KDFExplain() {
+  return (
+    <>
+      <p>
+        パスワードは人間が覚えやすい短い文字列ですが、
+        AESやHMACには<strong>十分な長さとランダム性を持つ鍵</strong>が必要です。
+        鍵導出関数（KDF）は、パスワードから暗号学的に安全な鍵を「引き伸ばす」技術です。
+      </p>
+
+      <div className="step-lesson__callout">
+        <strong>用語: KDF（Key Derivation Function）</strong><br />
+        短い入力（パスワード等）から、暗号鍵として使える長い擬似ランダムバイト列を導出する関数。
+        パスワードベースKDF（PBKDF2, bcrypt, Argon2）は意図的に計算を遅くして総当たり攻撃を防ぐ。
+      </div>
+
+      <div className="step-lesson__comparison">
+        <div className="step-lesson__comparison-item">
+          <h3>SHA-256でハッシュ化</h3>
+          <ul>
+            <li>超高速（攻撃者にも有利）</li>
+            <li>GPUで毎秒数十億回計算可能</li>
+            <li>ソルトなし→レインボーテーブル攻撃</li>
+            <li>パスワード保管には不適切</li>
+          </ul>
+        </div>
+        <div className="step-lesson__comparison-item">
+          <h3>PBKDF2 / Argon2</h3>
+          <ul>
+            <li>意図的に低速（反復回数で調整）</li>
+            <li>ソルトで同じパスワードでも異なる出力</li>
+            <li>Argon2はメモリも大量消費→GPU耐性</li>
+            <li>パスワード保管の標準手法</li>
+          </ul>
+        </div>
+      </div>
+    </>
+  )
+}
+
+/* =========================================
+   Step 12: PBKDF2デモ
+   ========================================= */
+function PBKDF2Demo() {
+  const [password, setPassword] = useState('MyPassword123')
+  const [salt, setSalt] = useState('random-salt-value')
+  const [iterations, setIterations] = useState(100000)
+  const [derivedKey, setDerivedKey] = useState('')
+  const [elapsed, setElapsed] = useState(0)
+  const [status, setStatus] = useState<'idle' | 'deriving' | 'done'>('idle')
+
+  const derive = async () => {
+    setStatus('deriving')
+    const t0 = performance.now()
+    const enc = new TextEncoder()
+    const keyMaterial = await crypto.subtle.importKey(
+      'raw', enc.encode(password), 'PBKDF2', false, ['deriveBits']
+    )
+    const bits = await crypto.subtle.deriveBits(
+      {
+        name: 'PBKDF2',
+        salt: enc.encode(salt),
+        iterations,
+        hash: 'SHA-256',
+      },
+      keyMaterial,
+      256,
+    )
+    const hex = [...new Uint8Array(bits)]
+      .map(b => b.toString(16).padStart(2, '0')).join('')
+    setDerivedKey(hex)
+    setElapsed(Math.round(performance.now() - t0))
+    setStatus('done')
+  }
+
+  const presets = [
+    { label: '1,000回（危険）', value: 1000 },
+    { label: '100,000回（最低限）', value: 100000 },
+    { label: '600,000回（OWASP推奨）', value: 600000 },
+  ]
+
+  return (
+    <>
+      <p>
+        PBKDF2（Password-Based Key Derivation Function 2）は、
+        パスワードに<strong>ソルト</strong>と<strong>反復回数</strong>を加えて鍵を導出します。
+        反復回数を変えて処理時間の変化を体感してみましょう。
+      </p>
+
+      <div className="step-lesson__demo-box">
+        <label className="step-lesson__label">パスワード</label>
+        <input
+          type="text"
+          className="step-lesson__input"
+          value={password}
+          onChange={e => { setPassword(e.target.value); setStatus('idle') }}
+        />
+
+        <label className="step-lesson__label">ソルト（ユーザーごとに異なるランダム値）</label>
+        <input
+          type="text"
+          className="step-lesson__input"
+          value={salt}
+          onChange={e => { setSalt(e.target.value); setStatus('idle') }}
+        />
+
+        <label className="step-lesson__label">反復回数</label>
+        <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem', flexWrap: 'wrap' }}>
+          {presets.map(p => (
+            <button
+              key={p.value}
+              className={`step-lesson__btn${iterations === p.value ? '' : ' step-lesson__btn--outline'}`}
+              onClick={() => { setIterations(p.value); setStatus('idle') }}
+              style={{ flex: 1, minWidth: '120px' }}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+
+        <button
+          className="step-lesson__btn"
+          onClick={derive}
+          disabled={!password || status === 'deriving'}
+        >
+          {status === 'deriving' ? '導出中…' : '鍵を導出する'}
+        </button>
+
+        {status === 'done' && (
+          <div style={{ marginTop: '1rem' }}>
+            <div style={{ marginBottom: '0.75rem' }}>
+              <strong>導出された鍵（256ビット）:</strong>
+              <div className="step-lesson__mono" style={{ wordBreak: 'break-all', fontSize: '0.8rem' }}>
+                {derivedKey}
+              </div>
+            </div>
+            <div style={{
+              padding: '0.75rem 1rem',
+              borderRadius: '8px',
+              background: 'var(--sl-color-surface)',
+              border: '1px solid var(--sl-color-border)',
+            }}>
+              <strong>処理時間: {elapsed} ms</strong>
+              <span style={{ fontSize: '0.85rem', color: 'var(--sl-color-muted)', marginLeft: '0.5rem' }}>
+                （反復 {iterations.toLocaleString()} 回）
+              </span>
+            </div>
+            <p style={{ marginTop: '0.75rem', fontSize: '0.85rem', color: 'var(--sl-color-muted)' }}>
+              {iterations <= 1000
+                ? '1,000回ではほぼ一瞬です。攻撃者がGPUで毎秒数百万のパスワードを試せてしまいます。'
+                : iterations <= 100000
+                ? '100,000回でも体感できる遅延が出ます。攻撃者の総当たりコストが大幅に上がります。'
+                : 'OWASP推奨の600,000回では明確な遅延があります。1パスワードの検証にこれだけかかるなら、数百万パターンの総当たりは現実的ではありません。'}
+            </p>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+/* =========================================
+   Step 13: KDFの比較と選び方
+   ========================================= */
+function KDFComparison() {
+  return (
+    <>
+      <p>
+        PBKDF2以外にも、より現代的なKDFがあります。
+        用途に応じて使い分けましょう。
+      </p>
+
+      <div className="step-lesson__table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>KDF</th>
+              <th>仕組み</th>
+              <th>GPU耐性</th>
+              <th>用途</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>PBKDF2</strong></td>
+              <td>HMAC-SHA256をN回反復</td>
+              <td>低い（計算のみ）</td>
+              <td>レガシー互換、WebCrypto対応</td>
+            </tr>
+            <tr>
+              <td><strong>bcrypt</strong></td>
+              <td>Blowfish暗号の鍵スケジュールを利用</td>
+              <td>中程度</td>
+              <td>多くのWebフレームワークのデフォルト</td>
+            </tr>
+            <tr>
+              <td><strong>scrypt</strong></td>
+              <td>大量メモリを要求</td>
+              <td>高い</td>
+              <td>ディスク暗号化等</td>
+            </tr>
+            <tr>
+              <td><strong>Argon2id</strong></td>
+              <td>メモリ＋計算コストを調整可能</td>
+              <td>非常に高い</td>
+              <td>OWASP推奨の第一選択</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div className="step-lesson__callout">
+        <strong>HKDF — もう一つのKDF:</strong><br />
+        HKDF（HMAC-based Key Derivation Function）は、
+        すでに十分なランダム性を持つ鍵素材（例: DH共有秘密）から
+        複数の鍵を導出するために使います。
+        パスワードのような低エントロピー入力には向きません。
+        TLSのハンドシェイクで広く使用されています。
+      </div>
+
+      <p>
+        <strong>選び方の指針:</strong>{' '}
+        パスワード保管には<strong>Argon2id</strong>が第一選択です。
+        WebCrypto APIで完結させたい場合は<strong>PBKDF2</strong>（反復600,000回以上）を使いましょう。
+        鍵素材からの鍵導出には<strong>HKDF</strong>を使います。
+      </p>
+    </>
+  )
+}
+
+/* =========================================
    メインコンポーネント
    ========================================= */
 export default function Hash() {
@@ -786,6 +1018,38 @@ export default function Hash() {
           { label: 'SHA-256は可逆だから' },
         ],
         explanation: '正解！SHA-256は高速に設計されているため、攻撃者も高速にハッシュを計算してパスワードを総当たりできます。bcryptやArgon2は意図的に計算を遅く（かつメモリも消費するように）設計されており、総当たり攻撃のコストを大幅に引き上げます。',
+      },
+    },
+    {
+      title: '鍵導出関数 — パスワードから鍵を作る',
+      content: <KDFExplain />,
+      quiz: {
+        question: 'パスワードからの鍵導出にSHA-256単体ではなくPBKDF2を使う最大の理由は？',
+        options: [
+          { label: 'SHA-256の出力長が足りないから' },
+          { label: 'SHA-256は不可逆ではないから' },
+          { label: '反復処理で意図的に遅くし、総当たり攻撃のコストを上げるため', correct: true },
+          { label: 'PBKDF2のほうがハッシュ値が長いから' },
+        ],
+        explanation: 'PBKDF2はHMAC-SHA256をN回反復することで、1回のパスワード検証にかかる時間を引き上げます。正規ユーザーには数百ミリ秒の遅延ですが、攻撃者が数百万パターンを試すには莫大な時間がかかります。',
+      },
+    },
+    {
+      title: 'PBKDF2デモ — 反復回数と処理時間',
+      content: <PBKDF2Demo />,
+    },
+    {
+      title: 'KDFの比較と選び方',
+      content: <KDFComparison />,
+      quiz: {
+        question: 'Argon2idがPBKDF2より総当たり攻撃に強い理由は？',
+        options: [
+          { label: 'ハッシュ関数が異なるから' },
+          { label: '計算コストだけでなく大量のメモリも要求するため、GPU並列攻撃が困難になるから', correct: true },
+          { label: '出力する鍵が長いから' },
+          { label: 'ソルトを使えるから' },
+        ],
+        explanation: 'PBKDF2は計算のみを反復するため、GPUの大量コアで並列処理できます。Argon2idはメモリも大量に消費するため、GPUのメモリ帯域がボトルネックになり、並列攻撃の効率が大幅に低下します。',
       },
     },
   ]

--- a/src/pages/PublicKey.tsx
+++ b/src/pages/PublicKey.tsx
@@ -177,7 +177,140 @@ function EllipticCurveIntuition() {
 }
 
 /* =========================================
-   Step 3: DH → ECDH の橋渡し
+   Step 3: 古典的DH鍵交換デモ（小さい数で体験）
+   ========================================= */
+function ClassicDHDemo() {
+  const [p] = useState(23)
+  const [g] = useState(5)
+  const [aliceSecret, setAliceSecret] = useState(6)
+  const [bobSecret, setBobSecret] = useState(15)
+
+  const modPow = (base: number, exp: number, mod: number): number => {
+    let result = 1
+    base = base % mod
+    while (exp > 0) {
+      if (exp % 2 === 1) result = (result * base) % mod
+      exp = Math.floor(exp / 2)
+      base = (base * base) % mod
+    }
+    return result
+  }
+
+  const alicePub = modPow(g, aliceSecret, p)
+  const bobPub = modPow(g, bobSecret, p)
+  const sharedAlice = modPow(bobPub, aliceSecret, p)
+  const sharedBob = modPow(alicePub, bobSecret, p)
+
+  return (
+    <>
+      <p>
+        Diffie-Hellman鍵交換を<strong>小さい数</strong>で実際に計算してみましょう。
+        AliceとBobが、盗聴されている通信路上で共通の秘密を作る過程を追います。
+      </p>
+
+      <div className="step-lesson__demo-box">
+        <div style={{ marginBottom: '1rem' }}>
+          <strong>公開パラメータ（誰でも知っている）:</strong>
+          <div className="step-lesson__mono" style={{ fontSize: '0.9rem' }}>
+            素数 p = {p}, 生成元 g = {g}
+          </div>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem', marginBottom: '1rem' }}>
+          <div>
+            <label className="step-lesson__label">Alice の秘密鍵 a</label>
+            <input
+              type="range"
+              min={2}
+              max={p - 2}
+              value={aliceSecret}
+              onChange={e => setAliceSecret(Number(e.target.value))}
+              style={{ width: '100%' }}
+            />
+            <div className="step-lesson__mono" style={{ textAlign: 'center' }}>{aliceSecret}</div>
+          </div>
+          <div>
+            <label className="step-lesson__label">Bob の秘密鍵 b</label>
+            <input
+              type="range"
+              min={2}
+              max={p - 2}
+              value={bobSecret}
+              onChange={e => setBobSecret(Number(e.target.value))}
+              style={{ width: '100%' }}
+            />
+            <div className="step-lesson__mono" style={{ textAlign: 'center' }}>{bobSecret}</div>
+          </div>
+        </div>
+
+        <div className="step-lesson__table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th></th>
+                <th>Alice</th>
+                <th>Bob</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>1. 秘密鍵を選ぶ</strong></td>
+                <td>a = {aliceSecret}</td>
+                <td>b = {bobSecret}</td>
+              </tr>
+              <tr>
+                <td><strong>2. 公開値を計算</strong></td>
+                <td>A = {g}^{aliceSecret} mod {p} = <strong>{alicePub}</strong></td>
+                <td>B = {g}^{bobSecret} mod {p} = <strong>{bobPub}</strong></td>
+              </tr>
+              <tr>
+                <td><strong>3. 公開値を交換</strong></td>
+                <td>Bobから B = {bobPub} を受信</td>
+                <td>Aliceから A = {alicePub} を受信</td>
+              </tr>
+              <tr>
+                <td><strong>4. 共有秘密を計算</strong></td>
+                <td>{bobPub}^{aliceSecret} mod {p} = <strong>{sharedAlice}</strong></td>
+                <td>{alicePub}^{bobSecret} mod {p} = <strong>{sharedBob}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div style={{
+          padding: '0.75rem 1rem',
+          borderRadius: '8px',
+          background: sharedAlice === sharedBob
+            ? 'var(--sl-color-success-bg, #c6f6d5)'
+            : 'var(--sl-color-danger-bg, #fed7d7)',
+          color: sharedAlice === sharedBob
+            ? 'var(--sl-color-success, #22543d)'
+            : 'var(--sl-color-danger, #822727)',
+          fontWeight: 'bold',
+          textAlign: 'center',
+          marginTop: '0.75rem',
+        }}>
+          共有秘密: {sharedAlice}（両者が同じ値を得た！）
+        </div>
+
+        <p style={{ marginTop: '0.75rem', fontSize: '0.85rem', color: 'var(--sl-color-muted)' }}>
+          盗聴者は p={p}, g={g}, A={alicePub}, B={bobPub} を知っていますが、
+          a={aliceSecret} や b={bobSecret} を知らないため共有秘密 {sharedAlice} を計算できません。
+          スライダーを動かして、秘密鍵を変えると共有秘密がどう変わるか観察してみましょう。
+        </p>
+      </div>
+
+      <div className="step-lesson__callout">
+        <strong>実際の鍵サイズ:</strong> この例では p=23（5ビット）ですが、
+        実用では2048ビット以上の素数を使います。
+        離散対数問題（g^a mod p から a を逆算する）の困難性が安全性の根拠です。
+      </div>
+    </>
+  )
+}
+
+/* =========================================
+   Step 4: DH → ECDH の橋渡し
    古典DH → 楕円曲線への写像 → ECDHプロトコル
    ========================================= */
 function DHToECDH() {
@@ -944,6 +1077,20 @@ export default function PublicKeyPage() {
           { label: '点の加算が不可能であること' },
         ],
         explanation: '正解！点GとスカラーnからQ = n・Gを計算するのは簡単ですが、GとQからnを逆算すること（ECDLP）は計算上不可能です。この非対称性が安全性の基盤です。',
+      },
+    },
+    {
+      title: '古典的DH鍵交換 — 小さい数で体験',
+      content: <ClassicDHDemo />,
+      quiz: {
+        question: 'DH鍵交換で盗聴者が共有秘密を計算できない理由は？',
+        options: [
+          { label: '通信が暗号化されているから' },
+          { label: '公開値A, Bから秘密鍵a, bを逆算する（離散対数問題）が計算上困難だから', correct: true },
+          { label: '素数pが秘密だから' },
+          { label: '公開値が毎回変わるから' },
+        ],
+        explanation: '盗聴者はp, g, A=g^a mod p, B=g^b mod p を知っていますが、AからaやBからbを求めるには離散対数問題を解く必要があり、pが十分大きければ計算上不可能です。',
       },
     },
     {

--- a/src/pages/PublicKey.tsx
+++ b/src/pages/PublicKey.tsx
@@ -106,7 +106,12 @@ function EllipticCurveIntuition() {
   return (
     <>
       <p>
-        現代の公開鍵暗号の多くは<strong>楕円曲線</strong>を使います。
+        前のステップで、古典的DHは<strong>2048ビット以上の巨大な素数</strong>が必要だと学びました。
+        鍵も通信データも大きくなり、モバイルやIoTには不向きです。
+        これを解決するのが<strong>楕円曲線</strong>です。
+        256ビットの楕円曲線鍵で、3072ビットのRSA鍵に匹敵する安全性を実現します。
+      </p>
+      <p>
         「楕円曲線」と聞くと難しそうですが、幾何学的には非常に美しい構造を持っています。
       </p>
 
@@ -340,11 +345,12 @@ function DHToECDH() {
   return (
     <>
       <p>
-        Diffie-Hellman鍵交換は、<strong>盗聴されている通信路でも安全に共通の秘密を作れる</strong>プロトコルです。
-        まず古典的なDHを理解し、次にそれが楕円曲線上でどう変わるかを見ていきましょう。
+        Step 2で古典的DHを体験し、Step 3で楕円曲線の数学を学びました。
+        ここではその2つを組み合わせます。
+        古典DHの各操作が、楕円曲線上の操作に<strong>1対1で対応</strong>していることを確認しましょう。
       </p>
 
-      <h3>古典的 Diffie-Hellman（整数上）</h3>
+      <h3>おさらい: 古典的 Diffie-Hellman（整数上）</h3>
       <div className="step-lesson__visual">
         <div style={{ fontFamily: 'var(--font-mono)', fontSize: '0.9rem', lineHeight: '2.2', textAlign: 'left', display: 'inline-block' }}>
           <div>公開パラメータ: 素数 p, 生成元 g</div>
@@ -1089,20 +1095,6 @@ export default function PublicKeyPage() {
       },
     },
     {
-      title: '楕円曲線の直感的理解',
-      content: <EllipticCurveIntuition />,
-      quiz: {
-        question: '楕円曲線暗号の安全性の根拠は何ですか？',
-        options: [
-          { label: '素因数分解の困難さ' },
-          { label: '楕円曲線上の離散対数問題（ECDLP）の困難さ', correct: true },
-          { label: '楕円曲線の方程式が複雑であること' },
-          { label: '点の加算が不可能であること' },
-        ],
-        explanation: '正解！点GとスカラーnからQ = n・Gを計算するのは簡単ですが、GとQからnを逆算すること（ECDLP）は計算上不可能です。この非対称性が安全性の基盤です。',
-      },
-    },
-    {
       title: '古典的DH鍵交換 — 小さい数で体験',
       content: <ClassicDHDemo />,
       quiz: {
@@ -1114,6 +1106,20 @@ export default function PublicKeyPage() {
           { label: '公開値が毎回変わるから' },
         ],
         explanation: '盗聴者はp, g, A=g^a mod p, B=g^b mod p を知っていますが、AからaやBからbを求めるには離散対数問題を解く必要があり、pが十分大きければ計算上不可能です。',
+      },
+    },
+    {
+      title: '楕円曲線の直感的理解',
+      content: <EllipticCurveIntuition />,
+      quiz: {
+        question: '楕円曲線暗号の安全性の根拠は何ですか？',
+        options: [
+          { label: '素因数分解の困難さ' },
+          { label: '楕円曲線上の離散対数問題（ECDLP）の困難さ', correct: true },
+          { label: '楕円曲線の方程式が複雑であること' },
+          { label: '点の加算が不可能であること' },
+        ],
+        explanation: '正解！点GとスカラーnからQ = n・Gを計算するのは簡単ですが、GとQからnを逆算すること（ECDLP）は計算上不可能です。この非対称性が安全性の基盤です。',
       },
     },
     {

--- a/src/pages/PublicKey.tsx
+++ b/src/pages/PublicKey.tsx
@@ -203,10 +203,23 @@ function ClassicDHDemo() {
 
   return (
     <>
+      <h3>問題: 盗聴者がいる通信路で、どうやって秘密を共有する？</h3>
       <p>
-        Diffie-Hellman鍵交換を<strong>小さい数</strong>で実際に計算してみましょう。
-        AliceとBobが、盗聴されている通信路上で共通の秘密を作る過程を追います。
+        AliceとBobがAES暗号で通信したいとします。しかしAESには共通鍵が必要です。
+        鍵をそのまま送れば盗聴者に読まれます。
+        かといって、二人は直接会ったことがなく、事前に鍵を共有する手段がありません。
       </p>
+      <p>
+        1976年にDiffieとHellmanが発見した解法は、<strong>「絵の具の混合」</strong>に似ています。
+        二人が公開の場で色を交換しても、混ぜた結果から元の色を分離するのは困難です。
+        数学的には<strong>べき乗の剰余演算</strong>がこの「混合」の役割を果たします。
+      </p>
+
+      <div className="step-lesson__callout">
+        <strong>注目ポイント:</strong> 下のデモでは、テーブルの各行が実際の通信ステップに対応しています。
+        <strong>行3「公開値を交換」</strong>で送られる A, B は盗聴者にも見えますが、
+        それだけでは<strong>行4の共有秘密を計算できない</strong>ことが、DHの核心です。
+      </div>
 
       <div className="step-lesson__demo-box">
         <div style={{ marginBottom: '1rem' }}>
@@ -294,16 +307,26 @@ function ClassicDHDemo() {
         </div>
 
         <p style={{ marginTop: '0.75rem', fontSize: '0.85rem', color: 'var(--sl-color-muted)' }}>
-          盗聴者は p={p}, g={g}, A={alicePub}, B={bobPub} を知っていますが、
-          a={aliceSecret} や b={bobSecret} を知らないため共有秘密 {sharedAlice} を計算できません。
           スライダーを動かして、秘密鍵を変えると共有秘密がどう変わるか観察してみましょう。
         </p>
       </div>
 
+      <h3>なぜ盗聴者は秘密を計算できないのか？</h3>
+      <p>
+        盗聴者は p={p}, g={g}, A={alicePub}, B={bobPub} の4つを知っています。
+        しかし共有秘密を得るには、A={alicePub} から a={aliceSecret} を逆算する必要があります。
+        つまり「{g}の何乗が {alicePub} になるか？」という問題（<strong>離散対数問題</strong>）を解かなければなりません。
+      </p>
+      <p>
+        p=23なら全探索で解けますが、実用では<strong>2048ビット以上の素数</strong>を使います。
+        この規模では離散対数問題に効率的な解法がなく、事実上計算不可能です。
+      </p>
+
       <div className="step-lesson__callout">
-        <strong>実際の鍵サイズ:</strong> この例では p=23（5ビット）ですが、
-        実用では2048ビット以上の素数を使います。
-        離散対数問題（g^a mod p から a を逆算する）の困難性が安全性の根拠です。
+        <strong>DHの限界 — 中間者攻撃:</strong> DHは盗聴に対しては安全ですが、
+        通信相手が本物かどうかは検証しません。攻撃者が間に入って
+        AliceともBobとも別々にDHを行う<strong>中間者攻撃（MITM）</strong>が可能です。
+        これを防ぐためにデジタル署名やPKI（公開鍵基盤）と組み合わせて使います。
       </div>
     </>
   )


### PR DESCRIPTION
## Summary
- Hash ページに鍵導出関数（PBKDF2）の解説・デモ・比較を3ステップ追加
- 公開鍵暗号ページに古典的DH鍵交換の体験デモを1ステップ追加
- 新規ページ・NavBarリンクは追加せず、既存ページへの組み込み

## 変更内容

### Hash.tsx（#44 鍵導出関数）
- **Step 11**: KDFの解説 — SHA-256単体 vs PBKDF2/Argon2の比較
- **Step 12**: PBKDF2デモ — 反復回数（1,000 / 100,000 / 600,000）を切り替えて処理時間を体感
- **Step 13**: KDFの比較と選び方 — PBKDF2 / bcrypt / scrypt / Argon2id / HKDF

### PublicKey.tsx（#54 DH鍵交換）
- **Step 3（新規）**: 古典的DH鍵交換デモ — p=23, g=5 の小さい数でAlice/Bobの計算過程を可視化。スライダーで秘密鍵を変更可能

## Test plan
- [x] `/hash` で全13ステップを通しで確認
- [x] PBKDF2デモ: 3つの反復回数で処理時間の変化を確認
- [x] `/labs` 公開鍵タブで全10ステップを通しで確認
- [x] DHデモ: スライダーで秘密鍵を変更→共有秘密が変わることを確認
- [x] モバイル表示の確認

Closes #44
Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)